### PR TITLE
Problem: rust-base64-sgx used in chain-core is being force-pushed

### DIFF
--- a/chain/chain-core/Cargo.toml
+++ b/chain/chain-core/Cargo.toml
@@ -19,7 +19,7 @@ secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", d
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = { version = "0.8", default-features = false }
 parity-scale-codec = { features = ["derive"], default-features = false, version = "1.0" }
-base64 = { git = "https://github.com/mesalock-linux/rust-base64-sgx.git", rev = "3bc16457fa44ed6f4cbc3c40804c38bde7d89e03" }
+base64 = { git = "https://github.com/mesalock-linux/rust-base64-sgx.git", rev = "c2fabd15f647f7b4ad1e003b8d742ea34951dad2" }
 sgx_tstd = { rev = "v1.0.8", git = "https://github.com/baidu/rust-sgx-sdk.git", optional = true }
 static_assertions = { version = "0.3.3", default-features = false}
 bech32 = { version = "0.7.1", optional = true }


### PR DESCRIPTION
Solution: Updated with latest commit