### PR TITLE
Problem: (CRO-289) rust-hex-sgx rev not found on build

### DIFF
--- a/chain/chain-core/Cargo.toml
+++ b/chain/chain-core/Cargo.toml
@@ -14,7 +14,7 @@ mesalock_sgx = ["sgx_tstd"]
 [dependencies]
 digest = { version = "0.8", default-features = false}
 tiny-keccak = { version = "1.5.0", default-features = false, features = ["keccak"] }
-hex = { git = "https://github.com/mesalock-linux/rust-hex-sgx.git", rev = "10618d76cc6f2aac8f356a882f1e85a1d8478998" }
+hex = { git = "https://github.com/mesalock-linux/rust-hex-sgx.git", rev = "c603c9f6cd929073d5d07171dce9f7cc8524a956" }
 secp256k1zkp = { git = "https://github.com/crypto-com/rust-secp256k1-zkp.git", default-features = false, rev = "ab780345c85ac2c28a4e0c08e8e18c4ecdbb1fa9", features = ["recovery", "endomorphism", "sgx"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 blake2 = { version = "0.8", default-features = false }


### PR DESCRIPTION
Solution: 📦 Changed rust-hex-sgx to use force-pushed commit

https://github.com/mesalock-linux/rust-hex-sgx/commit/c603c9f6cd929073d5d07171dce9f7cc8524a956