### PR TITLE
Problem: tx-query cert regenerated on every connection (CRO-360)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,3 +12,8 @@ This project contains portions of code derived from the following libraries:
  * Copyright: Copyright (c) 2019 Supercomputing Systems AG
  * License: Apache License 2.0
  * Repository: https://github.com/scs/substraTEE-worker
+
+* MesaTEE
+ * Copyright: Copyright (c) 2019 Baidu, Inc.
+ * License: Apache License 2.0
+ * Repository: https://github.com/mesalock-linux/mesatee

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://avatars0.githubusercontent.com/u/41934032?s=400&v=4" alt="Crypto.com Chain" width="400">
 </p>
 
-<h2 align="center">(Work in Progress) <a href="https://crypto.com">Crypto.com<a> Chain Transaction Enclaves</h2
+<h2 align="center">(Work in Progress) <a href="https://crypto.com">Crypto.com<a> Chain Transaction Enclaves</h2>
 
 For more details, see the [Crypto.com Chain README](https://github.com/crypto-com/chain)
 

--- a/tx-query/README.md
+++ b/tx-query/README.md
@@ -1,0 +1,47 @@
+
+# Transaction Decryption Query Enclave
+
+This transaction enclave allows semi-trusted client querying of sealed transaction payloads that were persisted by the transaction validation enclave on the same machine.
+
+For more details on the client side, see the [Crypto.com Chain README](https://github.com/crypto-com/chain) and `client-index`.
+
+## Build / Run
+This only works / makes sense in the hardware mode, see the [main README](../README.md).
+
+1. start the AESM Service / make sure it is running. For example, inside the Docker container, run:
+```
+LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
+```
+
+2. (if not done before) Build and run the [transaction validation enclave](../tx-validation).
+
+3. Build by `tx-query` running `make` 
+
+4. Make sure the below *required* environment variables are set and run `./tx-query-app <address:port to listen on> <tx-validation ZMQ connection string>`
+
+### Required Environment Variables
+
+You can obtain the SPID and API key (choose -- unlinkable quotes) here: https://api.portal.trustedservices.intel.com/EPID-attestation
+
+- `SPID`: "Service Provider ID" 
+- `IAS_API_KEY`: the primary or secondary API key for querying the Intel Attestation Service
+
+### Optional Environment Variables
+- `RUST_LOG`
+- `RUST_BACKTRACE`
+
+## (tx-validation "integration") Test
+1. start the AESM Service / make sure it is running. For example, inside the Docker container, run:
+```
+LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service &
+```
+
+2. (if not done before) Build (non-test) the [transaction validation enclave](../tx-validation).
+
+3. Build by running `SGX_TEST=1 make` 
+
+4. Make sure the above *required* environment variables are set
+
+5. Additional, set the `TX_VALIDATION_BIN_DIR` environment variable to the directory path where `tx-validation-app` binary resides
+
+6. Run `./tx-query-app`

--- a/tx-query/enclave/Cargo.toml
+++ b/tx-query/enclave/Cargo.toml
@@ -37,3 +37,5 @@ httparse    = { version = "1.3.2", default-features = false }
 itertools   = { version = "0.8", default-features = false, features = []}
 rustls      = { git = "https://github.com/mesalock-linux/rustls", branch = "mesalock_sgx" }
 webpki-roots= { git = "https://github.com/mesalock-linux/webpki-roots", branch = "mesalock_sgx" }
+lazy_static  = { version = "1.4", features = ["spin_no_std"] }
+zeroize = { version = "0.10.0", default-features = false, features = ["zeroize_derive"]}

--- a/tx-query/enclave/src/attest.rs
+++ b/tx-query/enclave/src/attest.rs
@@ -1,0 +1,673 @@
+use sgx_rand::*;
+use sgx_tcrypto::*;
+use sgx_tse::*;
+use sgx_types::*;
+
+use crate::cert::CertKeyPair;
+use core::hash::{Hash, Hasher};
+use lazy_static::lazy_static;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::prelude::v1::*;
+use std::ptr;
+use std::str;
+use std::string::String;
+use std::sync::Arc;
+use std::sync::SgxRwLock;
+use std::time::SystemTime;
+use std::untrusted::time::SystemTimeEx;
+use std::vec::Vec;
+use zeroize::Zeroize;
+
+pub const IAS_HOSTNAME: &'static str = "api.trustedservices.intel.com";
+#[cfg(not(feature = "production"))]
+pub const API_SUFFIX: &'static str = "/sgx/dev";
+#[cfg(feature = "production")]
+pub const API_SUFFIX: &'static str = "/sgx";
+pub const SIGRL_SUFFIX: &'static str = "/attestation/v3/sigrl/";
+pub const REPORT_SUFFIX: &'static str = "/attestation/v3/report";
+
+extern "C" {
+    pub fn ocall_sgx_init_quote(
+        ret_val: *mut sgx_status_t,
+        ret_ti: *mut sgx_target_info_t,
+        ret_gid: *mut sgx_epid_group_id_t,
+    ) -> sgx_status_t;
+    pub fn ocall_get_ias_key(
+        ret_val: *mut sgx_status_t,
+        ias_key: *mut u8,
+        ias_key_len: u32,
+    ) -> sgx_status_t;
+    pub fn ocall_get_ias_socket(ret_val: *mut sgx_status_t, ret_fd: *mut i32) -> sgx_status_t;
+    pub fn ocall_get_quote(
+        ret_val: *mut sgx_status_t,
+        p_sigrl: *const u8,
+        sigrl_len: u32,
+        p_report: *const sgx_report_t,
+        quote_type: sgx_quote_sign_type_t,
+        p_nonce: *const sgx_quote_nonce_t,
+        p_qe_report: *mut sgx_report_t,
+        p_quote: *mut u8,
+        maxlen: u32,
+        p_quote_len: *mut u32,
+    ) -> sgx_status_t;
+}
+
+struct RACache {
+    cert_key: CertKeyPair,
+    gen_time: SystemTime,
+}
+
+lazy_static! {
+    static ref RACACHE: SgxRwLock<RACache> = {
+        SgxRwLock::new(RACache {
+            cert_key: CertKeyPair {
+                cert: Vec::<u8>::new(),
+                private_key: crate::cert::PrivateKey::new(Vec::<u8>::new()),
+            },
+            gen_time: SystemTime::UNIX_EPOCH,
+        })
+    };
+
+    static ref IAS_CLIENT_CONFIG: Arc<rustls::ClientConfig> = {
+        let mut config = rustls::ClientConfig::new();
+
+        // We trust known CA
+        config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+        Arc::new(config)
+    };
+
+    static ref SVRCONFIGCACHE: SgxRwLock<HashMap<u64, Arc<rustls::ServerConfig>>> =
+        { SgxRwLock::new(HashMap::new()) };
+}
+
+fn is_tls_config_updated(gen_time: &SystemTime) -> bool {
+    let dur = SystemTime::now().duration_since(*gen_time);
+    // max one day diff
+    let max_allowed_diff = std::time::Duration::from_secs(86400u64);
+    dur.is_ok() && dur.unwrap() < max_allowed_diff
+}
+
+#[derive(Debug)]
+enum RAError {
+    ParseError,
+    RAInternalError,
+    MissingValue,
+    CommunicationError,
+    APIKeyError,
+    CertGeneration,
+}
+
+fn percent_decode(orig: String) -> Result<String, RAError> {
+    let v: Vec<&str> = orig.split('%').collect();
+    let mut ret = String::new();
+    ret.push_str(v[0]);
+    if v.len() > 1 {
+        for s in v[1..].iter() {
+            let digit = u8::from_str_radix(&s[0..2], 16).map_err(|_| RAError::ParseError)?;
+            ret.push(digit as char);
+            ret.push_str(&s[2..]);
+        }
+    }
+    Ok(ret)
+}
+
+fn sanitize_http_response(respp: &httparse::Response) -> Result<(), RAError> {
+    if let Some(code) = respp.code {
+        if code != 200 {
+            Err(RAError::RAInternalError)
+        } else {
+            Ok(())
+        }
+    } else {
+        Err(RAError::RAInternalError)
+    }
+}
+
+struct AttnReport {
+    pub report: String,
+    pub signature: String,
+    pub certificate: String,
+}
+
+fn parse_response_attn_report(resp: &[u8]) -> Result<AttnReport, RAError> {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut respp = httparse::Response::new(&mut headers);
+    let result = respp.parse(resp);
+
+    sanitize_http_response(&respp)?;
+
+    let mut sig = String::new();
+    let mut sig_cert = String::new();
+    let mut attn_report = String::new();
+
+    for header in respp.headers {
+        match header.name {
+            "Content-Length" => {
+                let len_str =
+                    String::from_utf8(header.value.to_vec()).map_err(|_| RAError::ParseError)?;
+                let len_num = len_str.parse::<u32>().map_err(|_| RAError::ParseError)?;
+                if len_num != 0 {
+                    let status = result.map_err(|_| RAError::ParseError)?;
+                    let header_len = match status {
+                        httparse::Status::Complete(l) => l,
+                        _ => {
+                            return Err(RAError::ParseError);
+                        }
+                    };
+                    let resp_body = &resp[header_len..];
+                    attn_report = str::from_utf8(resp_body)
+                        .map_err(|_| RAError::ParseError)?
+                        .to_string();
+                    // println!("Attestation report: {}", attn_report);
+                }
+            }
+            "X-IASReport-Signature" => {
+                sig = str::from_utf8(header.value)
+                    .map_err(|_| RAError::ParseError)?
+                    .to_string()
+            }
+            "X-IASReport-Signing-Certificate" => {
+                let mut cert = str::from_utf8(header.value)
+                    .map_err(|_| RAError::ParseError)?
+                    .to_string();
+                // Remove %0A from cert, and only obtain the signing cert
+                cert = cert.replace("%0A", "");
+                // We should get two concatenated PEM files at this step
+                cert = percent_decode(cert)?;
+                let cert_content: Vec<&str> = cert.split("-----").collect();
+                // expected number of parts
+                if cert_content.len() != 9 {
+                    return Err(RAError::MissingValue);
+                } else {
+                    sig_cert = cert_content[2].to_string();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(AttnReport {
+        report: attn_report,
+        signature: sig,
+        certificate: sig_cert,
+    })
+}
+
+fn parse_response_sigrl(resp: &[u8]) -> Result<Vec<u8>, RAError> {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut respp = httparse::Response::new(&mut headers);
+    let result = respp.parse(resp);
+
+    sanitize_http_response(&respp)?;
+    let header = respp
+        .headers
+        .iter()
+        .find(|&&header| header.name == "Content-Length")
+        .ok_or(RAError::ParseError)?;
+    let len_str = String::from_utf8(header.value.to_vec()).map_err(|_| RAError::ParseError)?;
+    let len_num = len_str.parse::<u32>().map_err(|_| RAError::ParseError)?;
+    if len_num == 0 {
+        Ok(Vec::new())
+    } else {
+        let status = result.map_err(|_| RAError::ParseError)?;
+        let header_len = match status {
+            httparse::Status::Complete(l) => l,
+            _ => {
+                return Err(RAError::ParseError);
+            }
+        };
+        let resp_body = &resp[header_len..];
+        let base64_body = str::from_utf8(resp_body).map_err(|_| RAError::ParseError)?;
+        base64::decode(base64_body).map_err(|_| RAError::ParseError)
+    }
+}
+
+fn get_sigrl_from_intel(ias_key: &str, fd: c_int, gid: u32) -> Result<Vec<u8>, RAError> {
+    // println!("get_sigrl_from_intel fd = {:?}", fd);
+
+    let req = format!("GET {}{}{:08x} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key: {}\r\nConnection: Close\r\n\r\n",
+                        API_SUFFIX,
+                        SIGRL_SUFFIX,
+                        gid,
+                        IAS_HOSTNAME,
+                        ias_key);
+
+    // println!("{}", req);
+
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str(IAS_HOSTNAME)
+        .map_err(|_| RAError::CommunicationError)?;
+    let mut sess = rustls::ClientSession::new(&IAS_CLIENT_CONFIG, dns_name);
+    let mut sock = TcpStream::new(fd).map_err(|_| RAError::CommunicationError)?;
+    let mut tls = rustls::Stream::new(&mut sess, &mut sock);
+
+    tls.write(req.as_bytes())
+        .map_err(|_| RAError::CommunicationError)?;
+    let mut plaintext = Vec::new();
+
+    // println!("write complete");
+
+    match tls.read_to_end(&mut plaintext) {
+        Ok(_) => (),
+        Err(_) => {
+            // println!("get_sigrl_from_intel tls.read_to_end: {:?}", e);
+            return Err(RAError::CommunicationError);
+        }
+    }
+    // println!("read_to_end complete");
+
+    parse_response_sigrl(&plaintext)
+}
+
+fn get_report_from_intel(ias_key: &str, fd: c_int, quote: Vec<u8>) -> Result<AttnReport, RAError> {
+    // println!("get_report_from_intel fd = {:?}", fd);
+    let encoded_quote = base64::encode(&quote[..]);
+    let encoded_json = format!("{{\"isvEnclaveQuote\":\"{}\"}}\r\n", encoded_quote);
+
+    let req = format!("POST {}{} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key:{}\r\nContent-Length:{}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
+                           API_SUFFIX,
+                           REPORT_SUFFIX,
+                           IAS_HOSTNAME,
+                           ias_key,
+                           encoded_json.len(),
+                           encoded_json);
+
+    // println!("{}", req);
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str(IAS_HOSTNAME)
+        .map_err(|_| RAError::CommunicationError)?;
+    let mut sess = rustls::ClientSession::new(&IAS_CLIENT_CONFIG, dns_name);
+    let mut sock = TcpStream::new(fd).map_err(|_| RAError::CommunicationError)?;
+    let mut tls = rustls::Stream::new(&mut sess, &mut sock);
+
+    tls.write(req.as_bytes())
+        .map_err(|_| RAError::CommunicationError)?;
+    let mut plaintext = Vec::new();
+
+    // println!("write complete");
+
+    tls.read_to_end(&mut plaintext)
+        .map_err(|_| RAError::CommunicationError)?;
+    // println!("read_to_end complete");
+    parse_response_attn_report(&plaintext)
+}
+
+#[allow(const_err)]
+fn create_attestation_report(
+    pub_k: &sgx_ec256_public_t,
+    ias_key: &str,
+    sign_type: sgx_quote_sign_type_t,
+) -> Result<(String, String, String), sgx_status_t> {
+    // Workflow:
+    // (1) ocall to get the target_info structure (ti) and epid group id (eg)
+    // (1.5) get sigrl
+    // (2) call sgx_create_report with ti+data, produce an sgx_report_t
+    // (3) ocall to sgx_get_quote to generate (*mut sgx-quote_t, uint32_t)
+
+    // (1) get ti + eg
+    let mut ti: sgx_target_info_t = sgx_target_info_t::default();
+    let mut eg: sgx_epid_group_id_t = sgx_epid_group_id_t::default();
+    let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
+
+    let res = unsafe {
+        ocall_sgx_init_quote(
+            &mut rt as *mut sgx_status_t,
+            &mut ti as *mut sgx_target_info_t,
+            &mut eg as *mut sgx_epid_group_id_t,
+        )
+    };
+
+    // println!("eg = {:?}", eg);
+
+    if res != sgx_status_t::SGX_SUCCESS {
+        return Err(res);
+    }
+
+    if rt != sgx_status_t::SGX_SUCCESS {
+        return Err(rt);
+    }
+
+    let eg_num = u32::from_le_bytes(eg);
+
+    // (1.5) get sigrl
+    let mut ias_sock: i32 = -1i32;
+
+    let mut sigrl_vec: Vec<u8> = Vec::new();
+    let mut sigrl_acquired: bool = false;
+
+    for _ in 0..3 {
+        let res = unsafe {
+            ocall_get_ias_socket(&mut rt as *mut sgx_status_t, &mut ias_sock as *mut i32)
+        };
+
+        if res != sgx_status_t::SGX_SUCCESS {
+            return Err(res);
+        }
+
+        if rt != sgx_status_t::SGX_SUCCESS {
+            return Err(rt);
+        }
+
+        //println!("Got ias_sock = {}", ias_sock);
+
+        // Now sigrl_vec is the revocation list, a vec<u8>
+        match get_sigrl_from_intel(ias_key, ias_sock, eg_num) {
+            Ok(v) => {
+                sigrl_vec = v;
+                sigrl_acquired = true;
+                break;
+            }
+            Err(_) => {
+                //println!("get sirl failed, retry...");
+            }
+        }
+    }
+
+    if !sigrl_acquired {
+        // println!("Cannot acquire sigrl from Intel for three times");
+        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
+    }
+
+    // (2) Generate the report
+    // Fill ecc256 public key into report_data
+    let mut report_data: sgx_report_data_t = sgx_report_data_t::default();
+    let mut pub_k_gx = pub_k.gx.clone();
+    pub_k_gx.reverse();
+    let mut pub_k_gy = pub_k.gy.clone();
+    pub_k_gy.reverse();
+    report_data.d[..32].clone_from_slice(&pub_k_gx);
+    report_data.d[32..].clone_from_slice(&pub_k_gy);
+
+    let rep = match rsgx_create_report(&ti, &report_data) {
+        Ok(r) => {
+            // println!("Report creation => success {:?}", r.body.mr_signer.m);
+            Some(r)
+        }
+        Err(e) => {
+            // println!("Report creation => failed {:?}", e);
+            return Err(e);
+        }
+    };
+
+    let mut quote_nonce = sgx_quote_nonce_t { rand: [0; 16] };
+    let mut os_rng = os::SgxRng::new().unwrap();
+    os_rng.fill_bytes(&mut quote_nonce.rand);
+    // println!("rand finished");
+    let mut qe_report = sgx_report_t::default();
+    const RET_QUOTE_BUF_LEN: u32 = 2048;
+    let mut return_quote_buf: [u8; RET_QUOTE_BUF_LEN as usize] = [0; RET_QUOTE_BUF_LEN as usize];
+    let mut quote_len: u32 = 0;
+
+    // (3) Generate the quote
+    // Args:
+    //       1. sigrl: ptr + len
+    //       2. report: ptr 432bytes
+    //       3. linkable: u32, unlinkable=0, linkable=1
+    //       4. spid: sgx_spid_t ptr 16bytes (retrieved inside the app)
+    //       5. sgx_quote_nonce_t ptr 16bytes
+    //       6. p_sig_rl + sigrl size ( same to sigrl)
+    //       7. [out]p_qe_report need further check
+    //       8. [out]p_quote
+    //       9. quote_size
+    let (p_sigrl, sigrl_len) = if sigrl_vec.len() == 0 {
+        (ptr::null(), 0)
+    } else {
+        (sigrl_vec.as_ptr(), sigrl_vec.len() as u32)
+    };
+    let p_report = (&rep.unwrap()) as *const sgx_report_t;
+    let quote_type = sign_type;
+
+    let p_nonce = &quote_nonce as *const sgx_quote_nonce_t;
+    let p_qe_report = &mut qe_report as *mut sgx_report_t;
+    let p_quote = return_quote_buf.as_mut_ptr();
+    let maxlen = RET_QUOTE_BUF_LEN;
+    let p_quote_len = &mut quote_len as *mut u32;
+
+    let result = unsafe {
+        ocall_get_quote(
+            &mut rt as *mut sgx_status_t,
+            p_sigrl,
+            sigrl_len,
+            p_report,
+            quote_type,
+            p_nonce,
+            p_qe_report,
+            p_quote,
+            maxlen,
+            p_quote_len,
+        )
+    };
+
+    if result != sgx_status_t::SGX_SUCCESS {
+        return Err(result);
+    }
+    if rt != sgx_status_t::SGX_SUCCESS {
+        // println!("ocall_get_quote returned {}", rt);
+        return Err(rt);
+    }
+
+    // Perform a check on qe_report to verify if the qe_report is valid
+    match rsgx_verify_report(&qe_report) {
+        Ok(()) => {
+            // println!("rsgx_verify_report passed!")
+        }
+        Err(x) => {
+            // println!("rsgx_verify_report failed with {:?}", x);
+            return Err(x);
+        }
+    }
+
+    // Check if the qe_report is produced on the same platform
+    if ti.mr_enclave.m != qe_report.body.mr_enclave.m
+        || ti.attributes.flags != qe_report.body.attributes.flags
+        || ti.attributes.xfrm != qe_report.body.attributes.xfrm
+    {
+        // println!("qe_report does not match current target_info!");
+        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
+    }
+
+    // println!("qe_report check passed");
+
+    // Debug
+    // for i in 0..quote_len {
+    //     print!("{:02X}", unsafe {*p_quote.offset(i as isize)});
+    // }
+    // println!("");
+
+    // Check qe_report to defend against replay attack
+    // The purpose of p_qe_report is for the ISV enclave to confirm the QUOTE
+    // it received is not modified by the untrusted SW stack, and not a replay.
+    // The implementation in QE is to generate a REPORT targeting the ISV
+    // enclave (target info from p_report) , with the lower 32Bytes in
+    // report.data = SHA256(p_nonce||p_quote). The ISV enclave can verify the
+    // p_qe_report and report.data to confirm the QUOTE has not be modified and
+    // is not a replay. It is optional.
+
+    let mut rhs_vec: Vec<u8> = quote_nonce.rand.to_vec();
+    rhs_vec.extend(&return_quote_buf[..quote_len as usize]);
+    let rhs_hash = rsgx_sha256_slice(&rhs_vec[..]).unwrap();
+    let lhs_hash = &qe_report.body.report_data.d[..32];
+
+    // println!("rhs hash = {:02X}", rhs_hash.iter().format(""));
+    // println!("report hs= {:02X}", lhs_hash.iter().format(""));
+
+    if rhs_hash != lhs_hash {
+        // println!("Quote is tampered!");
+        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
+    }
+
+    let quote_vec: Vec<u8> = return_quote_buf[..quote_len as usize].to_vec();
+    let res =
+        unsafe { ocall_get_ias_socket(&mut rt as *mut sgx_status_t, &mut ias_sock as *mut i32) };
+
+    if res != sgx_status_t::SGX_SUCCESS {
+        return Err(res);
+    }
+
+    if rt != sgx_status_t::SGX_SUCCESS {
+        return Err(rt);
+    }
+    let attn_report = get_report_from_intel(ias_key, ias_sock, quote_vec)
+        .map_err(|_| sgx_status_t::SGX_ERROR_UNEXPECTED)?;
+
+    Ok((
+        attn_report.report,
+        attn_report.signature,
+        attn_report.certificate,
+    ))
+}
+
+fn get_ra_cert() -> (CertKeyPair, bool) {
+    // Check if the global cert valid
+    // If valid, use it directly
+    // If invalid, update it before use.
+    // Generate Keypair
+
+    // 1. Check if the global cert valid
+    //    Need block read here. It should wait for writers to complete
+    {
+        // Unwrapping failing means the RwLock is poisoned.
+        // Simple crash in that case.
+        let cache = RACACHE.read().expect("read RA cache");
+        if is_tls_config_updated(&cache.gen_time) {
+            return (cache.cert_key.clone(), false);
+        }
+    }
+
+    // 2. Do the update
+
+    // Unwrapping failing means the RwLock is poisoned.
+    // Simple crash in that case.
+    let mut cache = RACACHE.write().expect("write RA cache");
+
+    // Here is the 100% serialized access to SVRCONFIG
+    // No other reader/writer exists in this branch
+    // Toc tou check
+    if is_tls_config_updated(&cache.gen_time) {
+        return (cache.cert_key.clone(), false);
+    }
+
+    // Do the renew
+    if renew_ra_cert(&mut cache).is_err() {
+        // If RA renewal fails, we do not crash for the following reasons.
+        // 1. Crashing the enclave causes most data to be lost permanently,
+        //    since we do not have persistent key-value storage yet. On the
+        //    other hand, RA renewal failure may be temporary. We still have
+        //    a chance to recover from this failure in the future.
+        // 2. If renewal failed, the old certificate is used, the the client
+        //    can decide if they want to keep talking to the enclave.
+        // 3. The certificate has a 90 days valid duration. If RA keeps
+        //    failing for 90 days, the enclave itself will not serve any
+        //    client.
+        panic!("RACACHE renewal failed");
+    }
+
+    (cache.cert_key.clone(), true)
+}
+
+fn renew_ra_cert(global_ra_cert: &mut RACache) -> Result<(), RAError> {
+    let mut ias_key = "00000000000000000000000000000000".to_owned();
+    let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
+    let result = unsafe {
+        ocall_get_ias_key(
+            &mut rt as *mut sgx_status_t,
+            ias_key.as_mut_ptr(),
+            ias_key.len() as u32,
+        )
+    };
+    if result != sgx_status_t::SGX_SUCCESS
+        || rt != sgx_status_t::SGX_SUCCESS
+        || !ias_key.chars().all(|x| x.is_alphanumeric())
+    {
+        return Err(RAError::APIKeyError);
+    }
+
+    // Generate Keypair
+    let ecc_handle = SgxEccHandle::new();
+    ecc_handle.open().map_err(|_| RAError::CertGeneration)?;
+    let (mut prv_k, pub_k) = ecc_handle
+        .create_key_pair()
+        .map_err(|_| RAError::CertGeneration)?;
+
+    let (attn_report, sig, cert) = match create_attestation_report(
+        &pub_k,
+        &ias_key,
+        sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
+    ) {
+        Ok(r) => r,
+        Err(_) => {
+            // println!("Error in create_attestation_report: {:?}", e);
+            return Err(RAError::CertGeneration);
+        }
+    };
+
+    let payload = attn_report + "|" + &sig + "|" + &cert;
+    let cert_key = match crate::cert::gen_ecc_cert(payload, &prv_k, &pub_k, &ecc_handle) {
+        Ok(r) => r,
+        Err(_) => {
+            // println!("Error in gen_ecc_cert: {:?}", e);
+            return Err(RAError::CertGeneration);
+        }
+    };
+    ecc_handle.close().map_err(|_| RAError::CertGeneration)?;
+    prv_k.r.zeroize();
+    global_ra_cert.cert_key = cert_key;
+    global_ra_cert.gen_time = SystemTime::now();
+
+    Ok(())
+}
+
+/// Returns the TLS session configuration
+/// fast path: it's in the cache (`SVRCONFIGCACHE` lazy static), so can be returned directly
+/// slow path: needs to generate a key pair, remotely attest the public key and generate the TLS certificate and configuration
+pub(crate) fn get_tls_config() -> Arc<rustls::ServerConfig> {
+    // To re-use existing TLS cache, we need to first check if the server has
+    // updated his RA cert
+    let (cert_key, invalidate_cache) = get_ra_cert();
+    let mut s = DefaultHasher::new();
+    cert_key.cert.hash(&mut s);
+    let stat_hash = s.finish();
+    // invalidate_cache is true iff. ra is renewed in the above func call
+    // if ra cert is pulled from cache, then we can try to do it quickly.
+    if !invalidate_cache {
+        if let Ok(cfg_cache) = SVRCONFIGCACHE.try_read() {
+            if let Some(cfg) = cfg_cache.get(&stat_hash) {
+                // Everything matched. Be quick!
+                return cfg.clone();
+            }
+        }
+    } else {
+        // ra cert is updated. so we need to invalidate the cache
+        // THIS IS BLOCKING!
+        match SVRCONFIGCACHE.write() {
+            Ok(mut cfg_cache) => {
+                //println!("SVRCONFIGCACHE invalidate all config cache!");
+                cfg_cache.clear();
+            }
+            Err(_) => {
+                // Poisoned
+                // println!("SVRCONFIGCACHE invalidate cache failed {}!", x);
+            }
+        }
+    }
+
+    // FIXME: client auth?
+    let authenticator = rustls::NoClientAuth::new();
+    let mut cfg = rustls::ServerConfig::new(authenticator);
+    let mut certs = Vec::new();
+    certs.push(rustls::Certificate(cert_key.cert));
+    let privkey = rustls::PrivateKey(cert_key.private_key.expose());
+
+    cfg.set_single_cert(certs, privkey).expect("TLS config");
+
+    let final_arc = Arc::new(cfg); // Create an Arc
+
+    if let Ok(mut cfg_cache) = SVRCONFIGCACHE.try_write() {
+        let _ = cfg_cache.insert(stat_hash, final_arc.clone()); // Overwrite
+    }
+    final_arc
+}

--- a/tx-query/enclave/src/lib.rs
+++ b/tx-query/enclave/src/lib.rs
@@ -9,20 +9,8 @@
 extern crate sgx_tstd as std;
 
 use sgx_rand::*;
-use sgx_tcrypto::*;
-use sgx_tse::*;
 use sgx_types::*;
 
-use std::io::{Read, Write};
-use std::net::{Shutdown, TcpStream};
-use std::prelude::v1::*;
-use std::ptr;
-use std::str;
-use std::string::String;
-use std::sync::Arc;
-use std::time::Duration;
-use std::vec::Vec;
-mod cert;
 use chain_core::state::account::WithdrawUnbondedTx;
 use chain_core::tx::data::attribute::TxAttributes;
 use chain_core::tx::data::Tx;
@@ -32,15 +20,18 @@ use enclave_protocol::{DecryptionRequest, DecryptionRequestBody, DecryptionRespo
 use parity_scale_codec::{Decode, Encode};
 use secp256k1::{key::PublicKey, Secp256k1};
 use sgx_tseal::SgxSealedData;
+use std::io::{Read, Write};
+use std::net::{Shutdown, TcpStream};
+use std::prelude::v1::*;
+use std::time::Duration;
+use std::vec::Vec;
+use zeroize::Zeroize;
 
-pub const IAS_HOSTNAME: &'static str = "api.trustedservices.intel.com";
-#[cfg(not(feature = "production"))]
-pub const API_SUFFIX: &'static str = "/sgx/dev";
-#[cfg(feature = "production")]
-pub const API_SUFFIX: &'static str = "/sgx";
-pub const SIGRL_SUFFIX: &'static str = "/attestation/v3/sigrl/";
-pub const REPORT_SUFFIX: &'static str = "/attestation/v3/report";
-pub const CERTEXPIRYDAYS: i64 = 90i64;
+/// functionality related to remote attestation (RA)
+mod attest;
+/// utility for generating the TLS cert with the RA payload
+mod cert;
+
 const TIMEOUT_SEC: u64 = 5;
 
 extern "C" {
@@ -51,395 +42,6 @@ extern "C" {
         txs: *mut u8,
         txs_len: u32,
     ) -> sgx_status_t;
-    pub fn ocall_sgx_init_quote(
-        ret_val: *mut sgx_status_t,
-        ret_ti: *mut sgx_target_info_t,
-        ret_gid: *mut sgx_epid_group_id_t,
-    ) -> sgx_status_t;
-    pub fn ocall_get_ias_key(
-        ret_val: *mut sgx_status_t,
-        ias_key: *mut u8,
-        ias_key_len: u32,
-    ) -> sgx_status_t;
-    pub fn ocall_get_ias_socket(ret_val: *mut sgx_status_t, ret_fd: *mut i32) -> sgx_status_t;
-    pub fn ocall_get_quote(
-        ret_val: *mut sgx_status_t,
-        p_sigrl: *const u8,
-        sigrl_len: u32,
-        p_report: *const sgx_report_t,
-        quote_type: sgx_quote_sign_type_t,
-        p_nonce: *const sgx_quote_nonce_t,
-        p_qe_report: *mut sgx_report_t,
-        p_quote: *mut u8,
-        maxlen: u32,
-        p_quote_len: *mut u32,
-    ) -> sgx_status_t;
-}
-
-fn parse_response_attn_report(resp: &[u8]) -> (String, String, String) {
-    // println!("parse_response_attn_report");
-    let mut headers = [httparse::EMPTY_HEADER; 16];
-    let mut respp = httparse::Response::new(&mut headers);
-    let result = respp.parse(resp);
-    // println!("parse result {:?}", result);
-
-    // FIXME: // FIXME: check respp.code!!!
-    let mut len_num: u32 = 0;
-
-    let mut sig = String::new();
-    let mut cert = String::new();
-    let mut attn_report = String::new();
-
-    for i in 0..respp.headers.len() {
-        let h = respp.headers[i];
-        //println!("{} : {}", h.name, str::from_utf8(h.value).unwrap());
-        match h.name {
-            "Content-Length" => {
-                let len_str = String::from_utf8(h.value.to_vec()).unwrap();
-                len_num = len_str.parse::<u32>().unwrap();
-                // println!("content length = {}", len_num);
-            }
-            "X-IASReport-Signature" => sig = str::from_utf8(h.value).unwrap().to_string(),
-            "X-IASReport-Signing-Certificate" => {
-                cert = str::from_utf8(h.value).unwrap().to_string()
-            }
-            _ => (),
-        }
-    }
-
-    // Remove %0A from cert, and only obtain the signing cert
-    cert = cert.replace("%0A", "");
-    cert = cert::percent_decode(cert);
-    let v: Vec<&str> = cert.split("-----").collect();
-    let sig_cert = v[2].to_string();
-
-    if len_num != 0 {
-        let header_len = result.unwrap().unwrap();
-        let resp_body = &resp[header_len..];
-        attn_report = str::from_utf8(resp_body).unwrap().to_string();
-        // println!("Attestation report: {}", attn_report);
-    }
-
-    // len_num == 0
-    (attn_report, sig, sig_cert)
-}
-
-fn parse_response_sigrl(resp: &[u8]) -> Vec<u8> {
-    // println!("parse_response_sigrl");
-    let mut headers = [httparse::EMPTY_HEADER; 16];
-    let mut respp = httparse::Response::new(&mut headers);
-    let result = respp.parse(resp);
-    // println!("parse result {:?}", result);
-    // println!("parse response{:?}", respp);
-
-    // FIXME: check respp.code!!!
-    let mut len_num: u32 = 0;
-
-    for i in 0..respp.headers.len() {
-        let h = respp.headers[i];
-        if h.name == "content-length" {
-            let len_str = String::from_utf8(h.value.to_vec()).unwrap();
-            len_num = len_str.parse::<u32>().unwrap();
-            // println!("content length = {}", len_num);
-        }
-    }
-
-    if len_num != 0 {
-        let header_len = result.unwrap().unwrap();
-        let resp_body = &resp[header_len..];
-        // println!("Base64-encoded SigRL: {:?}", resp_body);
-
-        return base64::decode(str::from_utf8(resp_body).unwrap()).unwrap();
-    }
-
-    // len_num == 0
-    Vec::new()
-}
-
-pub fn make_ias_client_config() -> rustls::ClientConfig {
-    let mut config = rustls::ClientConfig::new();
-
-    config
-        .root_store
-        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-
-    config
-}
-
-pub fn get_sigrl_from_intel(ias_key: &str, fd: c_int, gid: u32) -> Vec<u8> {
-    // println!("get_sigrl_from_intel fd = {:?}", fd);
-    let config = make_ias_client_config();
-
-    let req = format!("GET {}{}{:08x} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key: {}\r\nConnection: Close\r\n\r\n",
-                        API_SUFFIX,
-                        SIGRL_SUFFIX,
-                        gid,
-                        IAS_HOSTNAME,
-                        ias_key);
-
-    // println!("{}", req);
-
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str(IAS_HOSTNAME).unwrap();
-    let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);
-    let mut sock = TcpStream::new(fd).unwrap();
-    let mut tls = rustls::Stream::new(&mut sess, &mut sock);
-
-    let _result = tls.write(req.as_bytes());
-    let mut plaintext = Vec::new();
-
-    // println!("write complete");
-
-    match tls.read_to_end(&mut plaintext) {
-        Ok(_) => (),
-        Err(e) => {
-            // println!("get_sigrl_from_intel tls.read_to_end: {:?}", e);
-            panic!(e);
-        }
-    }
-    // println!("read_to_end complete");
-
-    parse_response_sigrl(&plaintext)
-}
-
-pub fn get_report_from_intel(ias_key: &str, fd: c_int, quote: Vec<u8>) -> (String, String, String) {
-    // println!("get_report_from_intel fd = {:?}", fd);
-    let config = make_ias_client_config();
-    let encoded_quote = base64::encode(&quote[..]);
-    let encoded_json = format!("{{\"isvEnclaveQuote\":\"{}\"}}\r\n", encoded_quote);
-
-    let req = format!("POST {}{} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key:{}\r\nContent-Length:{}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{}",
-                           API_SUFFIX,
-                           REPORT_SUFFIX,
-                           IAS_HOSTNAME,
-                           ias_key,
-                           encoded_json.len(),
-                           encoded_json);
-
-    // println!("{}", req);
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str(IAS_HOSTNAME).unwrap();
-    let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);
-    let mut sock = TcpStream::new(fd).unwrap();
-    let mut tls = rustls::Stream::new(&mut sess, &mut sock);
-
-    let _result = tls.write(req.as_bytes());
-    let mut plaintext = Vec::new();
-
-    // println!("write complete");
-
-    tls.read_to_end(&mut plaintext).unwrap();
-    // println!("read_to_end complete");
-
-    let (attn_report, sig, cert) = parse_response_attn_report(&plaintext);
-
-    (attn_report, sig, cert)
-}
-
-fn as_u32_le(array: &[u8; 4]) -> u32 {
-    ((array[0] as u32) << 0)
-        + ((array[1] as u32) << 8)
-        + ((array[2] as u32) << 16)
-        + ((array[3] as u32) << 24)
-}
-
-#[allow(const_err)]
-pub fn create_attestation_report(
-    pub_k: &sgx_ec256_public_t,
-    ias_key: &str,
-    sign_type: sgx_quote_sign_type_t,
-) -> Result<(String, String, String), sgx_status_t> {
-    // Workflow:
-    // (1) ocall to get the target_info structure (ti) and epid group id (eg)
-    // (1.5) get sigrl
-    // (2) call sgx_create_report with ti+data, produce an sgx_report_t
-    // (3) ocall to sgx_get_quote to generate (*mut sgx-quote_t, uint32_t)
-
-    // (1) get ti + eg
-    let mut ti: sgx_target_info_t = sgx_target_info_t::default();
-    let mut eg: sgx_epid_group_id_t = sgx_epid_group_id_t::default();
-    let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
-
-    let res = unsafe {
-        ocall_sgx_init_quote(
-            &mut rt as *mut sgx_status_t,
-            &mut ti as *mut sgx_target_info_t,
-            &mut eg as *mut sgx_epid_group_id_t,
-        )
-    };
-
-    // println!("eg = {:?}", eg);
-
-    if res != sgx_status_t::SGX_SUCCESS {
-        return Err(res);
-    }
-
-    if rt != sgx_status_t::SGX_SUCCESS {
-        return Err(rt);
-    }
-
-    let eg_num = as_u32_le(&eg);
-
-    // (1.5) get sigrl
-    let mut ias_sock: i32 = 0;
-
-    let res =
-        unsafe { ocall_get_ias_socket(&mut rt as *mut sgx_status_t, &mut ias_sock as *mut i32) };
-
-    if res != sgx_status_t::SGX_SUCCESS {
-        return Err(res);
-    }
-
-    if rt != sgx_status_t::SGX_SUCCESS {
-        return Err(rt);
-    }
-
-    //println!("Got ias_sock = {}", ias_sock);
-
-    // Now sigrl_vec is the revocation list, a vec<u8>
-    let sigrl_vec: Vec<u8> = get_sigrl_from_intel(ias_key, ias_sock, eg_num);
-
-    // (2) Generate the report
-    // Fill ecc256 public key into report_data
-    let mut report_data: sgx_report_data_t = sgx_report_data_t::default();
-    let mut pub_k_gx = pub_k.gx.clone();
-    pub_k_gx.reverse();
-    let mut pub_k_gy = pub_k.gy.clone();
-    pub_k_gy.reverse();
-    report_data.d[..32].clone_from_slice(&pub_k_gx);
-    report_data.d[32..].clone_from_slice(&pub_k_gy);
-
-    let rep = match rsgx_create_report(&ti, &report_data) {
-        Ok(r) => {
-            // println!("Report creation => success {:?}", r.body.mr_signer.m);
-            Some(r)
-        }
-        Err(e) => {
-            // println!("Report creation => failed {:?}", e);
-            return Err(e);
-        }
-    };
-
-    let mut quote_nonce = sgx_quote_nonce_t { rand: [0; 16] };
-    let mut os_rng = os::SgxRng::new().unwrap();
-    os_rng.fill_bytes(&mut quote_nonce.rand);
-    // println!("rand finished");
-    let mut qe_report = sgx_report_t::default();
-    const RET_QUOTE_BUF_LEN: u32 = 2048;
-    let mut return_quote_buf: [u8; RET_QUOTE_BUF_LEN as usize] = [0; RET_QUOTE_BUF_LEN as usize];
-    let mut quote_len: u32 = 0;
-
-    // (3) Generate the quote
-    // Args:
-    //       1. sigrl: ptr + len
-    //       2. report: ptr 432bytes
-    //       3. linkable: u32, unlinkable=0, linkable=1
-    //       4. spid: sgx_spid_t ptr 16bytes (retrieved inside the app)
-    //       5. sgx_quote_nonce_t ptr 16bytes
-    //       6. p_sig_rl + sigrl size ( same to sigrl)
-    //       7. [out]p_qe_report need further check
-    //       8. [out]p_quote
-    //       9. quote_size
-    let (p_sigrl, sigrl_len) = if sigrl_vec.len() == 0 {
-        (ptr::null(), 0)
-    } else {
-        (sigrl_vec.as_ptr(), sigrl_vec.len() as u32)
-    };
-    let p_report = (&rep.unwrap()) as *const sgx_report_t;
-    let quote_type = sign_type;
-
-    let p_nonce = &quote_nonce as *const sgx_quote_nonce_t;
-    let p_qe_report = &mut qe_report as *mut sgx_report_t;
-    let p_quote = return_quote_buf.as_mut_ptr();
-    let maxlen = RET_QUOTE_BUF_LEN;
-    let p_quote_len = &mut quote_len as *mut u32;
-
-    let result = unsafe {
-        ocall_get_quote(
-            &mut rt as *mut sgx_status_t,
-            p_sigrl,
-            sigrl_len,
-            p_report,
-            quote_type,
-            p_nonce,
-            p_qe_report,
-            p_quote,
-            maxlen,
-            p_quote_len,
-        )
-    };
-
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    if rt != sgx_status_t::SGX_SUCCESS {
-        // println!("ocall_get_quote returned {}", rt);
-        return Err(rt);
-    }
-
-    // Added 09-28-2018
-    // Perform a check on qe_report to verify if the qe_report is valid
-    match rsgx_verify_report(&qe_report) {
-        Ok(()) => {
-            // println!("rsgx_verify_report passed!")
-        }
-        Err(x) => {
-            // println!("rsgx_verify_report failed with {:?}", x);
-            return Err(x);
-        }
-    }
-
-    // Check if the qe_report is produced on the same platform
-    if ti.mr_enclave.m != qe_report.body.mr_enclave.m
-        || ti.attributes.flags != qe_report.body.attributes.flags
-        || ti.attributes.xfrm != qe_report.body.attributes.xfrm
-    {
-        // println!("qe_report does not match current target_info!");
-        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
-    }
-
-    // println!("qe_report check passed");
-
-    // Debug
-    // for i in 0..quote_len {
-    //     print!("{:02X}", unsafe {*p_quote.offset(i as isize)});
-    // }
-    // println!("");
-
-    // Check qe_report to defend against replay attack
-    // The purpose of p_qe_report is for the ISV enclave to confirm the QUOTE
-    // it received is not modified by the untrusted SW stack, and not a replay.
-    // The implementation in QE is to generate a REPORT targeting the ISV
-    // enclave (target info from p_report) , with the lower 32Bytes in
-    // report.data = SHA256(p_nonce||p_quote). The ISV enclave can verify the
-    // p_qe_report and report.data to confirm the QUOTE has not be modified and
-    // is not a replay. It is optional.
-
-    let mut rhs_vec: Vec<u8> = quote_nonce.rand.to_vec();
-    rhs_vec.extend(&return_quote_buf[..quote_len as usize]);
-    let rhs_hash = rsgx_sha256_slice(&rhs_vec[..]).unwrap();
-    let lhs_hash = &qe_report.body.report_data.d[..32];
-
-    // println!("rhs hash = {:02X}", rhs_hash.iter().format(""));
-    // println!("report hs= {:02X}", lhs_hash.iter().format(""));
-
-    if rhs_hash != lhs_hash {
-        // println!("Quote is tampered!");
-        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
-    }
-
-    let quote_vec: Vec<u8> = return_quote_buf[..quote_len as usize].to_vec();
-    let res =
-        unsafe { ocall_get_ias_socket(&mut rt as *mut sgx_status_t, &mut ias_sock as *mut i32) };
-
-    if res != sgx_status_t::SGX_SUCCESS {
-        return Err(res);
-    }
-
-    if rt != sgx_status_t::SGX_SUCCESS {
-        return Err(rt);
-    }
-
-    let (attn_report, sig, cert) = get_report_from_intel(ias_key, ias_sock, quote_vec);
-    Ok((attn_report, sig, cert))
 }
 
 #[inline]
@@ -466,14 +68,14 @@ fn check_unseal(
             }
         };
         let result = sealed_data.unseal_data();
-        let unsealed_data = match result {
+        let mut unsealed_data = match result {
             Ok(x) => x,
             Err(_) => {
                 return None;
             }
         };
         if unsealed_data.get_additional_txt() != txid {
-            // TODO: zeroize unsealed_data
+            unsealed_data.decrypt.zeroize();
             return None;
         }
         let otx = TxWithOutputs::decode(&mut unsealed_data.get_decrypt_txt());
@@ -483,23 +85,25 @@ fn check_unseal(
                 attributes: TxAttributes { allowed_view, .. },
                 ..
             })) => {
-                // TODO: policy != alldata
+                // TODO: policy != alldata + const eq?
                 push = allowed_view.iter().any(|x| x.view_key == view_key);
             }
             Ok(TxWithOutputs::StakeWithdraw(WithdrawUnbondedTx {
                 attributes: TxAttributes { allowed_view, .. },
                 ..
             })) => {
-                // TODO: policy != alldata
+                // TODO: policy != alldata + const eq?
                 push = allowed_view.iter().any(|x| x.view_key == view_key);
             }
             _ => {
+                unsealed_data.decrypt.zeroize();
                 return None;
             }
         }
         if push {
             return_result.push(otx.unwrap());
         }
+        unsealed_data.decrypt.zeroize();
     }
     Some(return_result)
 }
@@ -530,63 +134,21 @@ fn process_request(body: &DecryptionRequestBody) -> Option<DecryptionResponse> {
     }
 }
 
+/// The main routine:
+/// 0. is passed in the TCP client socket
+/// 1. creates a TLS server session
+/// either from a cached configuration / cert
+/// or generates a fresh one (quite involved, as it involves the remote attestation)
+/// 2. sends a random payload/challenge to the client
+/// 3. (client replies with a signed decryption request that includes the challenge)
+/// 4. verifies the decryption request
+/// 5. if OK, it processes it:
+/// - asks the tx-validation enclave to send back sealed transaction payloads
+/// - unseales the transactions and checks if the metadata contains the view key in the request
+/// - if so, it includes the transaction in the reply and sends it back
 #[no_mangle]
 pub extern "C" fn run_server(socket_fd: c_int) -> sgx_status_t {
-    // FIXME: cache cert+attestation report
-    let mut ias_key = "00000000000000000000000000000000".to_owned();
-    let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
-    let result = unsafe {
-        ocall_get_ias_key(
-            &mut rt as *mut sgx_status_t,
-            ias_key.as_mut_ptr(),
-            ias_key.len() as u32,
-        )
-    };
-    if result != sgx_status_t::SGX_SUCCESS
-        || rt != sgx_status_t::SGX_SUCCESS
-        || !ias_key.chars().all(|x| x.is_alphanumeric())
-    {
-        return sgx_status_t::SGX_ERROR_UNEXPECTED;
-    }
-
-    // Generate Keypair
-    let ecc_handle = SgxEccHandle::new();
-    let _result = ecc_handle.open();
-    let (prv_k, pub_k) = ecc_handle.create_key_pair().unwrap();
-
-    let (attn_report, sig, cert) = match create_attestation_report(
-        &pub_k,
-        &ias_key,
-        sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            // println!("Error in create_attestation_report: {:?}", e);
-            return e;
-        }
-    };
-
-    let payload = attn_report + "|" + &sig + "|" + &cert;
-    let (key_der, cert_der) = match cert::gen_ecc_cert(payload, &prv_k, &pub_k, &ecc_handle) {
-        Ok(r) => r,
-        Err(e) => {
-            // println!("Error in gen_ecc_cert: {:?}", e);
-            return e;
-        }
-    };
-    let _result = ecc_handle.close();
-
-    // FIXME: client auth?
-    let authenticator = rustls::NoClientAuth::new();
-    let mut cfg = rustls::ServerConfig::new(authenticator);
-    let mut certs = Vec::new();
-    certs.push(rustls::Certificate(cert_der));
-    let privkey = rustls::PrivateKey(key_der);
-
-    cfg.set_single_cert_with_ocsp_and_sct(certs, privkey, vec![], vec![])
-        .unwrap();
-
-    let mut sess = rustls::ServerSession::new(&Arc::new(cfg));
+    let mut sess = rustls::ServerSession::new(&attest::get_tls_config());
     let mut conn = TcpStream::new(socket_fd).unwrap();
     let _ = conn.set_read_timeout(Some(Duration::new(TIMEOUT_SEC, 0)));
     let _ = conn.set_write_timeout(Some(Duration::new(TIMEOUT_SEC, 0)));


### PR DESCRIPTION
Solution:
- extended the test to try two queries (to see the latency difference
(before it was about 3 seconds on each; now, it's only on the first one)
- moved the IAS stuff into a separate module and ported some of the MesaTEE
  more robust handling of establishing attested TLS connections
  + having a lazy static cache of certs / TLS configurations
- added some documentation + readme