### PR TITLE
Bump sled  to "0.27"

### DIFF
--- a/tx-validation/app/Cargo.toml
+++ b/tx-validation/app/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 sgx-test = []
 
 [dependencies]
-sled = "0.24.1"
+sled = "0.27"
 hex = "0.3"
 dirs = "1.0.2"
 zmq = "0.9"


### PR DESCRIPTION
Fails to build enclave with sled 0.26. 
Bumped and tested with 0.27